### PR TITLE
feat: add recipe endopint

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	port := ":1111"
 
 	router.HandleFunc("/recipe/{id}", recipe).Methods("GET")
-	router.HandleFunc("/recipe/add", add).Methods("GET")
+	router.HandleFunc("/recipe/add", add).Methods("POST")
 	router.HandleFunc("/recipe/list/{number}", createList).Methods("GET")
 	router.HandleFunc("/", index).Methods("GET")
 
@@ -36,11 +36,18 @@ func index(rw http.ResponseWriter, req *http.Request) {
 	rw.Write(recipesJson)
 }
 
-// TODO: implement method
 func add(rw http.ResponseWriter, req *http.Request) {
+	var res map[string]interface{}
+	json.NewDecoder(req.Body).Decode(&res)
+
+	id := data.AddRecipe(res)
+	idJson, err := json.Marshal(id)
+
+	data.CheckError(err)
+
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(http.StatusCreated)
-	rw.Write([]byte("add"))
+	rw.Write(idJson)
 }
 
 func recipe(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
- Implements `/recipe/add` endpoint
   - serializes `id` field of inserted recipe
   - For now, accepts the following curl Post
      - ```curl -X POST http://localhost:1111/recipe/add -d '{ "Name": "Moms Spaghetti", "Instructions": ["His palms are sweaty", "knees weak, arms are heavy", "Theres vomit on his sweater already"], "Ingredients": ["one", "two", "three", "four"] }' -H "Content-Type: application/json"```

**Mealbuddy PostgreSQL tables before**
<img width="1024" alt="mealbuddy tables - before" src="https://github.com/eulloa/meal-buddy/assets/4174313/bbf50936-b2fa-427f-9aec-c1b2b7ff7974">

**Mealbuddy PostgreSQL tables after**
<img width="1042" alt="mealbuddy tables - after" src="https://github.com/eulloa/meal-buddy/assets/4174313/733689e1-b546-469c-bda1-89b132cf9636">
