### PR TITLE
feat: implement delete endpoint

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -184,7 +184,22 @@ func AddRecipe(res map[string]interface{}) int {
 	_, insExecErr := insStmt.Exec(pq.Array(r.Instructions), id)
 	CheckError(insExecErr)
 
+	defer db.Close()
 	return id
+}
+
+func DeleteRecipe(id int) {
+	db := connect()
+
+	stmt, err := db.Prepare("DELETE FROM recipes WHERE id = $1")
+
+	CheckError(err)
+
+	_, stmtErr := stmt.Exec(id)
+
+	CheckError(stmtErr)
+
+	defer db.Close()
 }
 
 func contains(slice []string, item string) bool {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	router.HandleFunc("/recipe/{id}", recipe).Methods("GET")
 	router.HandleFunc("/recipe/add", add).Methods("POST")
 	router.HandleFunc("/recipe/list/{number}", createList).Methods("GET")
+	router.HandleFunc("/recipe/delete/{id}", delete).Methods("DELETE")
 	router.HandleFunc("/", index).Methods("GET")
 
 	handler := cors.Default().Handler(router)
@@ -78,4 +79,14 @@ func createList(rw http.ResponseWriter, req *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(http.StatusCreated)
 	rw.Write(rJson)
+}
+
+func delete(rw http.ResponseWriter, req *http.Request) {
+	id, err := strconv.Atoi(mux.Vars(req)["id"])
+
+	data.CheckError(err)
+
+	data.DeleteRecipe(id)
+
+	rw.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
- Implements `/recipe/delete/{id}` endpoint

**Recipes table before**
<img width="1031" alt="mealbuddy recipe table - before" src="https://github.com/eulloa/meal-buddy/assets/4174313/66cafab4-5540-4c83-9de4-29d4e848a9ee">

**curl -X Delete**
<img width="1030" alt="DELETE :recipe:delete" src="https://github.com/eulloa/meal-buddy/assets/4174313/1e44b7c8-e1e8-4afa-a236-5ca12825e802">

**Recipes table after**
<img width="1032" alt="mealbuddy recipe table - after" src="https://github.com/eulloa/meal-buddy/assets/4174313/7e2e0991-63ff-48fd-9ddb-b45a97e36f1d">
