### PR TITLE
feat: error handling GetRecipe

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,11 +55,19 @@ func recipe(rw http.ResponseWriter, req *http.Request) {
 	id, convErr := strconv.Atoi(mux.Vars(req)["id"])
 
 	data.CheckError(convErr)
+	db := data.Connect()
 
-	r := data.GetRecipe(id)
-	recipeJson, err := json.Marshal(r)
+	r, err := data.GetRecipe(db, id)
 
-	data.CheckError(err)
+	if err != nil {
+		j, _ := json.Marshal(err)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusNotFound)
+		rw.Write(j)
+		return
+	}
+
+	recipeJson, _ := json.Marshal(r)
 
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
- Improves error handling for `/recipe/{id}` GET endpoint
   - modifies `GetRecipe` method signature to:
      - accept a *sql.DB parameter to facilitate testing
      - return both recipe and error for improved error handling
- Exports `Connect` method in data package for dependency injection and to facilitate testing
   
<img width="510" alt="GetRecipe - error handling" src="https://github.com/eulloa/meal-buddy-api/assets/4174313/77f4ffb8-bb38-4374-8f28-d428af8f664d">
