### PR TITLE
feat: AddRecipe error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,10 +41,19 @@ func add(rw http.ResponseWriter, req *http.Request) {
 	var res map[string]interface{}
 	json.NewDecoder(req.Body).Decode(&res)
 
-	id := data.AddRecipe(res)
-	idJson, err := json.Marshal(id)
+	db := data.Connect()
 
-	data.CheckError(err)
+	id, rErr := data.AddRecipe(db, res)
+
+	if rErr != nil {
+		j, _ := json.Marshal(rErr)
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusBadRequest)
+		rw.Write(j)
+		return
+	}
+
+	idJson, _ := json.Marshal(id)
 
 	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
- Changes to `/recipe/add` endpoint
   - Modify `AddRecipe` signature to accept parameter of type `*sql.DB` to facilitate dependency injection + testing and also return both an int and an `ErrorString` struct to improve error handling
   - Modify private `sanitize` function to return an `ErrorString` struct or `nil` if it encounters an error to facilitate testing 