### PR TITLE
feat: implement connection pooling

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -4,15 +4,18 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
-
 	"strconv"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/lib/pq"
 	_ "github.com/lib/pq"
 )
 
-var vars = getVars()
+var (
+	vars = getVars()
+	db   *sql.DB
+)
 
 type Recipe struct {
 	Description  string   `json:"description"`
@@ -25,12 +28,12 @@ type Recipe struct {
 }
 
 type IRecipe interface {
-	AddRecipe(db *sql.DB, vals map[string]interface{}) (int, *ErrorString)
-	CreateRecipeList(db *sql.DB, n int) (*[]Recipe, *ErrorString)
-	DeleteRecipe(db *sql.DB, id int) *ErrorString
-	GetAllRecipes(db *sql.DB) []Recipe
-	GetRecipe(db *sql.DB, id int) (*Recipe, *ErrorString)
-	UpdateRecipe(db *sql.DB, id int) (int, *ErrorString)
+	AddRecipe(vals map[string]interface{}) (int, *ErrorString)
+	CreateRecipeList(n int) (*[]Recipe, *ErrorString)
+	DeleteRecipe(id int) *ErrorString
+	GetAllRecipes() []Recipe
+	GetRecipe(id int) (*Recipe, *ErrorString)
+	UpdateRecipe(id int) (int, *ErrorString)
 }
 
 type ErrorString struct {
@@ -53,9 +56,8 @@ func getVars() map[string]string {
 	return envs
 }
 
-func Connect() *sql.DB {
+func InitDB() {
 	port, err := strconv.Atoi(vars["PORT"])
-
 	CheckError(err)
 
 	conn := fmt.Sprintf(
@@ -63,18 +65,25 @@ func Connect() *sql.DB {
 		vars["HOST"], port, vars["USER"], vars["PASSWORD"], vars["DBNAME"],
 	)
 
-	db, connErr := sql.Open("postgres", conn)
-
+	var connErr error
+	db, connErr = sql.Open("postgres", conn)
 	CheckError(connErr)
 
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(10)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
 	pingErr := db.Ping()
-
 	CheckError(pingErr)
-
-	return db
 }
 
-func (r Recipe) GetAllRecipes(db *sql.DB) []Recipe {
+func CloseDB() {
+	if db != nil {
+		db.Close()
+	}
+}
+
+func (r Recipe) GetAllRecipes() []Recipe {
 	rows, queryErr := db.Query("SELECT id, name, description, image, ingredients, instructions, url FROM recipes r INNER JOIN ingredients ing ON r.id = ing.recipe_id INNER JOIN instructions ins ON r.id = ins.recipe_id")
 
 	CheckError(queryErr)
@@ -89,12 +98,11 @@ func (r Recipe) GetAllRecipes(db *sql.DB) []Recipe {
 	}
 
 	defer rows.Close()
-	defer db.Close()
 
 	return rs
 }
 
-func (r Recipe) GetRecipe(db *sql.DB, id int) (*Recipe, *ErrorString) {
+func (r Recipe) GetRecipe(id int) (*Recipe, *ErrorString) {
 	stmt, prepareErr := db.Prepare("SELECT id, name, description, image, ingredients, instructions, url FROM recipes r INNER JOIN ingredients ing ON r.id = ing.recipe_id INNER JOIN instructions ins ON r.id = ins.recipe_id WHERE r.id = $1")
 
 	if prepareErr != nil {
@@ -111,12 +119,11 @@ func (r Recipe) GetRecipe(db *sql.DB, id int) (*Recipe, *ErrorString) {
 		}
 	}
 
-	defer db.Close()
 	return &r, nil
 }
 
-func (r Recipe) CreateRecipeList(db *sql.DB, recipesInList int) (*[]Recipe, *ErrorString) {
-	recipes := r.GetAllRecipes(db)
+func (r Recipe) CreateRecipeList(recipesInList int) (*[]Recipe, *ErrorString) {
+	recipes := r.GetAllRecipes()
 	length := len(recipes)
 	var list []Recipe
 
@@ -141,12 +148,11 @@ func (r Recipe) CreateRecipeList(db *sql.DB, recipesInList int) (*[]Recipe, *Err
 		}
 	}
 
-	defer db.Close()
 	return &list, nil
 }
 
 // TODO: return (*Recipe, *ErrorString)
-func (r Recipe) AddRecipe(db *sql.DB, data map[string]interface{}) (int, *ErrorString) {
+func (r Recipe) AddRecipe(data map[string]interface{}) (int, *ErrorString) {
 	err := sanitize(data)
 
 	if err != nil {
@@ -223,11 +229,10 @@ func (r Recipe) AddRecipe(db *sql.DB, data map[string]interface{}) (int, *ErrorS
 		}
 	}
 
-	defer db.Close()
 	return id, nil
 }
 
-func (r Recipe) DeleteRecipe(db *sql.DB, id int) *ErrorString {
+func (r Recipe) DeleteRecipe(id int) *ErrorString {
 	stmt, err := db.Prepare("DELETE FROM recipes WHERE id = $1")
 
 	if err != nil {
@@ -244,11 +249,10 @@ func (r Recipe) DeleteRecipe(db *sql.DB, id int) *ErrorString {
 		}
 	}
 
-	defer db.Close()
 	return nil
 }
 
-func (r Recipe) UpdateRecipe(db *sql.DB, id int, data map[string]interface{}) (*Recipe, *ErrorString) {
+func (r Recipe) UpdateRecipe(id int, data map[string]interface{}) (*Recipe, *ErrorString) {
 	sErr := sanitize(data)
 
 	if sErr != nil {
@@ -303,7 +307,6 @@ func (r Recipe) UpdateRecipe(db *sql.DB, id int, data map[string]interface{}) (*
 		}
 	}
 
-	defer db.Close()
 	return &r, nil
 }
 

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -263,16 +263,17 @@ func TestCheckError_NonNilError(t *testing.T) {
 
 func setupMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
 	t.Helper()
-	db, mock, err := sqlmock.New()
+	mockDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to open sqlmock: %s", err)
 	}
-	return db, mock
+	db = mockDB
+	return mockDB, mock
 }
 
 func TestGetRecipe_Success(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "name", "description", "image", "ingredients", "instructions", "url"}).
 		AddRow(1, "Pasta", "Delicious pasta", "pasta.png",
@@ -281,7 +282,7 @@ func TestGetRecipe_Success(t *testing.T) {
 	mock.ExpectPrepare("SELECT .+ FROM recipes").ExpectQuery().WithArgs(1).WillReturnRows(rows)
 
 	recipe := new(Recipe)
-	result, err := recipe.GetRecipe(db, 1)
+	result, err := recipe.GetRecipe(1)
 
 	if err != nil {
 		t.Errorf("expected no error, got: %s", err.Error)
@@ -305,14 +306,14 @@ func TestGetRecipe_Success(t *testing.T) {
 }
 
 func TestGetRecipe_NotFound(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	mock.ExpectPrepare("SELECT .+ FROM recipes").ExpectQuery().WithArgs(999).
 		WillReturnError(sql.ErrNoRows)
 
 	recipe := new(Recipe)
-	result, err := recipe.GetRecipe(db, 999)
+	result, err := recipe.GetRecipe(999)
 
 	if result != nil {
 		t.Error("expected nil result for non-existent recipe")
@@ -332,14 +333,14 @@ func TestGetRecipe_NotFound(t *testing.T) {
 // --- DeleteRecipe tests (sqlmock) ---
 
 func TestDeleteRecipe_Success(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	mock.ExpectPrepare("DELETE FROM recipes").ExpectExec().WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	recipe := new(Recipe)
-	err := recipe.DeleteRecipe(db, 1)
+	err := recipe.DeleteRecipe(1)
 
 	if err != nil {
 		t.Errorf("expected no error, got: %s", err.Error)
@@ -351,14 +352,14 @@ func TestDeleteRecipe_Success(t *testing.T) {
 }
 
 func TestDeleteRecipe_PrepareError(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	mock.ExpectPrepare("DELETE FROM recipes").
 		WillReturnError(errors.New("prepare failed"))
 
 	recipe := new(Recipe)
-	err := recipe.DeleteRecipe(db, 1)
+	err := recipe.DeleteRecipe(1)
 
 	if err == nil {
 		t.Fatal("expected error on prepare failure, got nil")
@@ -369,14 +370,14 @@ func TestDeleteRecipe_PrepareError(t *testing.T) {
 }
 
 func TestDeleteRecipe_ExecError(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	mock.ExpectPrepare("DELETE FROM recipes").ExpectExec().WithArgs(1).
 		WillReturnError(errors.New("exec failed"))
 
 	recipe := new(Recipe)
-	err := recipe.DeleteRecipe(db, 1)
+	err := recipe.DeleteRecipe(1)
 
 	if err == nil {
 		t.Fatal("expected error on exec failure, got nil")
@@ -389,8 +390,8 @@ func TestDeleteRecipe_ExecError(t *testing.T) {
 // --- GetAllRecipes tests (sqlmock) ---
 
 func TestGetAllRecipes_Success(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "name", "description", "image", "ingredients", "instructions", "url"}).
 		AddRow(1, "Pasta", "Desc1", "img1.png", `{"flour"}`, `{"boil"}`, "https://a.com").
@@ -399,7 +400,7 @@ func TestGetAllRecipes_Success(t *testing.T) {
 	mock.ExpectQuery("SELECT .+ FROM recipes").WillReturnRows(rows)
 
 	recipe := new(Recipe)
-	result := recipe.GetAllRecipes(db)
+	result := recipe.GetAllRecipes()
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 recipes, got %d", len(result))
@@ -417,15 +418,15 @@ func TestGetAllRecipes_Success(t *testing.T) {
 }
 
 func TestGetAllRecipes_Empty(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	rows := sqlmock.NewRows([]string{"id", "name", "description", "image", "ingredients", "instructions", "url"})
 
 	mock.ExpectQuery("SELECT .+ FROM recipes").WillReturnRows(rows)
 
 	recipe := new(Recipe)
-	result := recipe.GetAllRecipes(db)
+	result := recipe.GetAllRecipes()
 
 	if len(result) != 0 {
 		t.Errorf("expected 0 recipes, got %d", len(result))
@@ -439,8 +440,8 @@ func TestGetAllRecipes_Empty(t *testing.T) {
 // --- AddRecipe tests (sqlmock) ---
 
 func TestAddRecipe_Success(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := validData()
 
@@ -456,7 +457,7 @@ func TestAddRecipe_Success(t *testing.T) {
 	mock.ExpectExec("INSERT INTO instructions").WillReturnResult(sqlmock.NewResult(0, 1))
 
 	recipe := new(Recipe)
-	id, err := recipe.AddRecipe(db, data)
+	id, err := recipe.AddRecipe(data)
 
 	if err != nil {
 		t.Errorf("expected no error, got: %s", err.Error)
@@ -471,15 +472,15 @@ func TestAddRecipe_Success(t *testing.T) {
 }
 
 func TestAddRecipe_SanitizeError(t *testing.T) {
-	db, _ := setupMockDB(t)
-	defer db.Close()
+	mockDB, _ := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := map[string]interface{}{
 		"Name": "",
 	}
 
 	recipe := new(Recipe)
-	id, err := recipe.AddRecipe(db, data)
+	id, err := recipe.AddRecipe(data)
 
 	if err == nil {
 		t.Fatal("expected sanitize error, got nil")
@@ -490,8 +491,8 @@ func TestAddRecipe_SanitizeError(t *testing.T) {
 }
 
 func TestAddRecipe_PrepareInsertError(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := validData()
 
@@ -499,7 +500,7 @@ func TestAddRecipe_PrepareInsertError(t *testing.T) {
 		WillReturnError(errors.New("prepare failed"))
 
 	recipe := new(Recipe)
-	id, err := recipe.AddRecipe(db, data)
+	id, err := recipe.AddRecipe(data)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -513,8 +514,8 @@ func TestAddRecipe_PrepareInsertError(t *testing.T) {
 }
 
 func TestAddRecipe_ExecInsertError(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := validData()
 
@@ -522,7 +523,7 @@ func TestAddRecipe_ExecInsertError(t *testing.T) {
 		WillReturnError(errors.New("exec failed"))
 
 	recipe := new(Recipe)
-	id, err := recipe.AddRecipe(db, data)
+	id, err := recipe.AddRecipe(data)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -536,8 +537,8 @@ func TestAddRecipe_ExecInsertError(t *testing.T) {
 }
 
 func TestAddRecipe_SelectIdError(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := validData()
 
@@ -548,7 +549,7 @@ func TestAddRecipe_SelectIdError(t *testing.T) {
 		WillReturnError(errors.New("prepare failed"))
 
 	recipe := new(Recipe)
-	id, err := recipe.AddRecipe(db, data)
+	id, err := recipe.AddRecipe(data)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -564,8 +565,8 @@ func TestAddRecipe_SelectIdError(t *testing.T) {
 // --- UpdateRecipe tests (sqlmock) ---
 
 func TestUpdateRecipe_Success(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := validData()
 
@@ -577,7 +578,7 @@ func TestUpdateRecipe_Success(t *testing.T) {
 	mock.ExpectExec("UPDATE instructions").WillReturnResult(sqlmock.NewResult(0, 1))
 
 	recipe := new(Recipe)
-	result, err := recipe.UpdateRecipe(db, 1, data)
+	result, err := recipe.UpdateRecipe(1, data)
 
 	if err != nil {
 		t.Errorf("expected no error, got: %s", err.Error)
@@ -595,15 +596,15 @@ func TestUpdateRecipe_Success(t *testing.T) {
 }
 
 func TestUpdateRecipe_SanitizeError(t *testing.T) {
-	db, _ := setupMockDB(t)
-	defer db.Close()
+	mockDB, _ := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := map[string]interface{}{
 		"Name": "",
 	}
 
 	recipe := new(Recipe)
-	result, err := recipe.UpdateRecipe(db, 1, data)
+	result, err := recipe.UpdateRecipe(1, data)
 
 	if err == nil {
 		t.Fatal("expected sanitize error, got nil")
@@ -614,8 +615,8 @@ func TestUpdateRecipe_SanitizeError(t *testing.T) {
 }
 
 func TestUpdateRecipe_PrepareError(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := validData()
 
@@ -623,7 +624,7 @@ func TestUpdateRecipe_PrepareError(t *testing.T) {
 		WillReturnError(errors.New("prepare failed"))
 
 	recipe := new(Recipe)
-	result, err := recipe.UpdateRecipe(db, 1, data)
+	result, err := recipe.UpdateRecipe(1, data)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -634,8 +635,8 @@ func TestUpdateRecipe_PrepareError(t *testing.T) {
 }
 
 func TestUpdateRecipe_ExecError(t *testing.T) {
-	db, mock := setupMockDB(t)
-	defer db.Close()
+	mockDB, mock := setupMockDB(t)
+	defer mockDB.Close()
 
 	data := validData()
 
@@ -643,7 +644,7 @@ func TestUpdateRecipe_ExecError(t *testing.T) {
 		WillReturnError(errors.New("exec failed"))
 
 	recipe := new(Recipe)
-	result, err := recipe.UpdateRecipe(db, 1, data)
+	result, err := recipe.UpdateRecipe(1, data)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")

--- a/main.go
+++ b/main.go
@@ -13,6 +13,9 @@ import (
 )
 
 func main() {
+	data.InitDB()
+	defer data.CloseDB()
+
 	router := mux.NewRouter()
 	port := ":1111"
 
@@ -29,11 +32,9 @@ func main() {
 }
 
 func index(rw http.ResponseWriter, req *http.Request) {
-	db := data.Connect()
-
 	r := new(data.Recipe)
 
-	recipes := r.GetAllRecipes(db)
+	recipes := r.GetAllRecipes()
 	recipesJson, err := json.Marshal(recipes)
 
 	data.CheckError(err)
@@ -47,10 +48,9 @@ func add(rw http.ResponseWriter, req *http.Request) {
 	var res map[string]interface{}
 	json.NewDecoder(req.Body).Decode(&res)
 
-	db := data.Connect()
 	r := new(data.Recipe)
 
-	recipe, rErr := r.AddRecipe(db, res)
+	recipe, rErr := r.AddRecipe(res)
 
 	if rErr != nil {
 		j, _ := json.Marshal(rErr)
@@ -83,10 +83,8 @@ func recipe(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	db := data.Connect()
-
 	r := new(data.Recipe)
-	recipe, err := r.GetRecipe(db, id)
+	recipe, err := r.GetRecipe(id)
 
 	if err != nil {
 		j, _ := json.Marshal(err)
@@ -119,11 +117,9 @@ func createList(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	db := data.Connect()
-
 	r := new(data.Recipe)
 
-	recipes, err := r.CreateRecipeList(db, numOfRecipes)
+	recipes, err := r.CreateRecipeList(numOfRecipes)
 
 	if err != nil {
 		j, _ := json.Marshal(err)
@@ -156,10 +152,9 @@ func delete(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	db := data.Connect()
 	r := new(data.Recipe)
 
-	dErr := r.DeleteRecipe(db, id)
+	dErr := r.DeleteRecipe(id)
 
 	if dErr != nil {
 		j, _ := json.Marshal(dErr)
@@ -188,11 +183,10 @@ func update(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	db := data.Connect()
 	r := new(data.Recipe)
 	var data map[string]interface{}
 	json.NewDecoder(req.Body).Decode(&data)
-	updated, rErr := r.UpdateRecipe(db, id, data)
+	updated, rErr := r.UpdateRecipe(id, data)
 
 	if rErr != nil {
 		j, _ := json.Marshal(rErr)


### PR DESCRIPTION
### Summary of changes

**data/data.go**
- Added InitDB() — opens one *sql.DB handle and configures the pool: MaxOpenConns(25), MaxIdleConns(10), ConnMaxLifetime(5min)
- Added CloseDB() — for graceful shutdown
- Removed Connect() and all defer db.Close() calls from data methods
- Removed db *sql.DB parameter from the IRecipe interface and all method signatures — methods now use the package-level pool

**main.go**
- Added data.InitDB() + defer data.CloseDB() in main()
- Removed all 6 db := data.Connect() calls from handlers
- Removed db argument from all method calls

**data/data_test.go**
- Updated setupMockDB to assign the mock to the package-level db
- Removed db argument from all method calls in tests