### PR TITLE
refactor: contains

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strconv"
 	"time"
 
@@ -338,16 +339,6 @@ func recipeFromMap(data map[string]interface{}) Recipe {
 	}
 }
 
-func contains(slice []string, item string) bool {
-	for _, v := range slice {
-		if item == v {
-			return true
-		}
-	}
-
-	return false
-}
-
 func sanitize(res map[string]interface{}) *ErrorString {
 	required := []string{"Description", "Image", "Ingredients", "Instructions", "Name", "Url"}
 	validKeys := make([]string, 0)
@@ -381,7 +372,7 @@ func sanitize(res map[string]interface{}) *ErrorString {
 		}
 
 		// check all required keys (and no redundant ones) are passed
-		c := contains(required, k)
+		c := slices.Contains(required, k)
 
 		if !c {
 			invalidKeys = append(invalidKeys, k)

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -9,41 +9,6 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
-// --- contains tests ---
-
-func TestContains_Found(t *testing.T) {
-	slice := []string{"apple", "banana", "cherry"}
-	if !contains(slice, "banana") {
-		t.Error("expected contains to return true for 'banana'")
-	}
-}
-
-func TestContains_NotFound(t *testing.T) {
-	slice := []string{"apple", "banana", "cherry"}
-	if contains(slice, "grape") {
-		t.Error("expected contains to return false for 'grape'")
-	}
-}
-
-func TestContains_EmptySlice(t *testing.T) {
-	if contains([]string{}, "apple") {
-		t.Error("expected contains to return false for empty slice")
-	}
-}
-
-func TestContains_EmptyString(t *testing.T) {
-	slice := []string{"", "banana"}
-	if !contains(slice, "") {
-		t.Error("expected contains to return true for empty string in slice")
-	}
-}
-
-func TestContains_SingleElement(t *testing.T) {
-	if !contains([]string{"only"}, "only") {
-		t.Error("expected contains to return true for single matching element")
-	}
-}
-
 // --- sanitize tests ---
 
 func validData() map[string]interface{} {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eulloa/meal-buddy
 
-go 1.15
+go 1.26.5
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect


### PR DESCRIPTION
- refactors legacy `contains` method (originally implemented because go version `1.15` did not include an official `contains` method) to use [slices.Contains](https://pkg.go.dev/slices#Contains)
- updates go version from `1.15` to `1.26.5`